### PR TITLE
fixed a crash when switching weapons while reloading and in cover

### DIFF
--- a/iv_weapAnims/weapAnims.cpp
+++ b/iv_weapAnims/weapAnims.cpp
@@ -614,6 +614,9 @@ void preProcessShotgunReload(CTaskSimpleReloadGun* pTask, CPed* pPed) {
 				auto currAmmoInClip = pWeapData->getNumAmmoInClip();
 				auto currNumAmmo = pWeapData->getTotalNumAmmo();
 
+				if(!pWeapData)
+					return;
+
 				if (currAmmoInClip != ammoInClip || currNumAmmo != numAmmo) {
 					pWeapData->setNumAmmoInClip(ammoInClip);
 					pWeapData->setTotalNumAmmo(numAmmo);
@@ -1039,3 +1042,4 @@ void processWeapIk(CPed* pPed) {
 }
 
 #endif
+


### PR DESCRIPTION
this also exposes a new bug where the weapon reloading animation keeps playing after you switch to hands mid-reload then back to the weapon but I couldn't figure out how to fix it.